### PR TITLE
aichat proxy cleanup (plan A):

### DIFF
--- a/chat-local.template.js
+++ b/chat-local.template.js
@@ -1,15 +1,19 @@
 /**
- * 本地开发配置模板
- * 使用方法：
- * 1. 复制此文件到 source/js/chat-local.js
- * 2. 填入你的API密钥和配置
- * 3. 本地开发时会自动使用这些配置
- * 
- * 注意：chat-local.js 已被 .gitignore 忽略，不会提交到仓库
+ * 本地直连配置模板（已废弃）
+ *
+ * 说明：从 2025-09-08 起，前端 chat.js 统一走 Cloudflare Workers 代理，
+ * 不再在前端注入/保存任何 API Key。本模板仅作为历史文档保留。
+ *
+ * 本地开发建议：使用 Cloudflare Wrangler 启动本地 Worker 代理进行联调
+ *   1) cd cloudflare-worker
+ *   2) wrangler dev
+ * 然后前端继续访问代理地址（proxyUrl），即可完成本地调试。
+ *
+ * 注意：如果你依然复制到 source/js/chat-local.js，它也不会被 chat.js 读取。
  */
 
-// 本地开发配置
-window.CHAT_LOCAL_KEY = 'your-api-key-here';
-window.CHAT_LOCAL_MODEL = '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05';
-window.CHAT_LOCAL_BASE = 'https://huggingface.qzz.io';
-window.CHAT_LOCAL_STREAMING = true;
+// 已废弃：以下字段不再被前端读取
+// window.CHAT_LOCAL_KEY = 'your-api-key-here';
+// window.CHAT_LOCAL_MODEL = '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05';
+// window.CHAT_LOCAL_BASE = 'https://huggingface.qzz.io';
+// window.CHAT_LOCAL_STREAMING = true;

--- a/source/_data/body-end.njk
+++ b/source/_data/body-end.njk
@@ -98,4 +98,4 @@
   });
 })();
 </script>
-<script src="/js/chat.js?v=20250908-01" data-pjax></script>
+<script src="/js/chat.js?v=20250908-02" data-pjax></script>

--- a/source/_posts/ai-chat-proxy-on-hexo.md
+++ b/source/_posts/ai-chat-proxy-on-hexo.md
@@ -1,0 +1,126 @@
+---
+title: 高粱米博客的 AI 聊天系统实战：从零到稳定
+categories:
+  - 技术记录与分享
+  - AI && LLM
+tags:
+  - AI-LLM
+  - Hexo
+  - Cloudflare Workers
+  - CORS
+  - Service Worker
+  - PJAX
+  - 部署排错
+author: Mako & Cascade
+abbrlink: bfdcb374
+date: 2025-09-08 04:02:20
+---
+
+这是一篇记录从零打造并稳定上线「高粱米 AI 姐姐」聊天系统的实战总结。项目基于 Hexo + NexT，前端纯静态，通过 Cloudflare Workers 作为安全代理完成与 OpenAI 兼容接口的对接。
+
+## 目标与约束
+
+- 前端纯静态，不暴露任何密钥
+- 流式输出、连续对话、轻量 UI
+- 具备速率限制和来源校验，防滥用
+- GitHub Pages 自动部署，故障可快速回滚
+
+## 架构设计
+
+- 前端：`source/js/chat.js`
+  - 通过 `STATE.globalConfig.proxyUrl` 统一指向 Worker 代理
+  - 两条路径：非流式与流式（SSE），均走代理
+  - 本地开发：推荐使用 `wrangler dev` 启动本地 Workers 代理；前端不再注入 API Key（不再支持直连）
+- 代理：Cloudflare Worker `chat-proxy`
+  - 环境变量：`CHAT_API_KEY`、`ALLOWED_ORIGINS`
+  - 速率限制（KV 可选）：每小时/每日
+  - CORS 处理，阻断非白名单来源
+  - 仅允许受控 model 列表
+
+## 核心演进与坑点
+
+1) 代理地址与优先级
+- 现象：控制台仍然请求旧域名
+- 根因：PJAX + 浏览器缓存 + localStorage 旧配置覆盖
+- 方案：代码优先使用 `global.proxyUrl`，并给 `chat.js` 增加版本号参数强制刷新
+
+2) Service Worker 安装失败
+- 现象：`addAll` 404、`installing worker became redundant`
+- 根因：GitHub Pages 上的路径不一，预缓存名单失配
+- 方案：更换为极简透传 SW（只 skipWaiting/clients.claim，不做缓存拦截）
+
+3) UI 可拖拽“漂移”
+- 现象：入口气泡可被拖到奇怪位置、记忆后影响体验
+- 方案：默认关闭拖拽（`entryBubbleDraggable: false`），需要时再手动开启
+
+4) CORS 与来源校验
+- 现象：`Failed to fetch` / `Origin not allowed`
+- 方案：Worker 中检查 `Origin` 是否包含 `https://zhu-jl18.github.io`（或其它白名单），OPTIONS 预检返回 200 + CORS 头
+
+5) 清理废弃的 API Base / API Key 前端配置
+- 现象：设置面板里仍能看到 API Base / API Key，但实际请求已统一走 Worker 代理
+  - 方案：移除前端的 API Base / API Key 字段与本地直连逻辑（`CHAT_LOCAL_*`），统一使用 `proxyUrl`；`chat.js` 已精简设置面板为仅选择模型
+
+## 本地开发与测试（统一代理）
+
+- 前置环境
+  - 启动 Hexo 本地服务（默认 http://localhost:4000）：
+    ```bash
+    npm run server
+    ```
+  - 启动 Cloudflare Worker 本地代理（默认 http://127.0.0.1:8787）：
+    ```bash
+    cd cloudflare-worker
+    wrangler dev
+    ```
+
+- 指定本地代理地址（两选一）
+  - 使用浏览器控制台设置持久覆盖（推荐）：
+    ```js
+    localStorage.setItem('chat-proxy-override', 'http://127.0.0.1:8787');
+    location.reload();
+    ```
+  - 临时变量（刷新后失效）：
+    ```js
+    window.CHAT_PROXY_DEV = 'http://127.0.0.1:8787';
+    ```
+
+- 验证
+  - 打开网页 → 开发者工具 → Network，确认聊天请求发往 `127.0.0.1:8787`。
+  - 代理会校验 `Origin`。当前 `chat-proxy.js` 默认允许 `localhost:4000/127.0.0.1:4000`；若需更严格控制，可在 Cloudflare Dashboard 的 `ALLOWED_ORIGINS` 中显式加入本地地址。
+  - 预检（OPTIONS）应返回 200，并带有 CORS 头（见 `handleCORS()`）。
+
+- 恢复生产代理
+  ```js
+  localStorage.removeItem('chat-proxy-override');
+  location.reload();
+  ```
+
+## 部署与回滚
+
+- 分支：`develop` 开发 → PR → `main` 自动部署（GitHub Actions）
+- 缓存处置：新版本发布后，给关键脚本带版本号；必要时在浏览器 DevTools 中清理 SW 与缓存
+- 回滚：强制推送 `main` 到上一稳定提交（紧急时使用）
+
+## 速查清单
+
+- Worker 环境变量：
+  - `CHAT_API_KEY`：真实 API Key
+  - `ALLOWED_ORIGINS`：`https://zhu-jl18.github.io`
+- 快速探活：
+  ```bash
+  curl -I https://chat-proxy.nontrivial2025.workers.dev
+  ```
+- 前端清本地配置：
+  ```js
+  localStorage.removeItem('chatcfg.v2')
+  ```
+- 常见报错：
+  - `ERR_BLOCKED_BY_CLIENT`：被广告拦截插件拦截，非功能性错误
+  - SW 404：使用极简 SW；若安装失败，先 Unregister 再刷新
+  - 仍走旧域名：确认脚本已带版本号、清理缓存
+
+## 致谢
+
+- 开发：Mako & Cascade（级联的含义是把复杂问题拆成有序步骤，像瀑布一样推进）
+- 特别感谢每次“线上 real-time 排障”的耐心与果断，这个系统在不断打磨中变得越来越稳。

--- a/source/js/chat.js
+++ b/source/js/chat.js
@@ -11,30 +11,28 @@
 
   // 加载全局配置
   function loadGlobalConfig(){
-    const local = isLocalHost();
-    // 本地开发时可以使用本地配置，线上使用代理模式
-    if (local && window.CHAT_LOCAL_KEY) {
-      // 本地开发模式：直接调用API
-      STATE.globalConfig = {
-        mode: 'direct',
-        defaultBase: 'https://huggingface.qzz.io',
-        apiKey: window.CHAT_LOCAL_KEY,
-        defaultModel: window.CHAT_LOCAL_MODEL || '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05'
-      };
-      console.log('本地开发模式：直接API调用');
-    } else {
-      // 生产模式：使用Cloudflare Workers代理
-      STATE.globalConfig = {
-        mode: 'proxy',
-        proxyUrl: 'https://chat-proxy.nontrivial2025.workers.dev', // 你的Worker URL
-        defaultModel: '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05',
-        models: [
-          '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05',
-          '[CLI反代]gemini-2.5-pro-preview-06-05'
-        ]
-      };
-      console.log('生产模式：使用Cloudflare Workers代理');
-    }
+    // 统一使用 Cloudflare Workers 代理模式（已移除本地直连与前端密钥配置）
+    STATE.globalConfig = {
+      mode: 'proxy',
+      proxyUrl: 'https://chat-proxy.nontrivial2025.workers.dev', // 你的Worker URL
+      defaultModel: '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05',
+      models: [
+        '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05',
+        '[CLI反代]gemini-2.5-pro-preview-06-05'
+      ]
+    };
+    // 本地开发覆盖：允许指定本地代理（不涉及前端密钥）
+    try {
+      if (isLocalHost()) {
+        const ls = localStorage.getItem('chat-proxy-override') || localStorage.getItem('chat_proxy_override');
+        const dev = (typeof window !== 'undefined' && window.CHAT_PROXY_DEV) || (ls && ls.trim());
+        if (dev) {
+          STATE.globalConfig.proxyUrl = dev;
+          console.log('[chat] 使用本地代理覆盖:', dev);
+        }
+      }
+    } catch(e) { /* ignore */ }
+    console.log('生产模式：使用Cloudflare Workers代理', STATE.globalConfig.proxyUrl);
   }
 
   function isLocalHost(){
@@ -45,11 +43,9 @@
     const local = isLocalHost();
     const global = STATE.globalConfig || {};
     return {
-      // 使用Cloudflare Workers代理，不再需要直接的API Base
+      // 使用 Cloudflare Workers 代理；已不再需要 API Base / API Key
       chatProxy: global.proxyUrl || 'https://chat-proxy.nontrivial2025.workers.dev',
-      chatBase: 'https://huggingface.qzz.io', // 仅用于显示，实际不使用
-      chatKey: '', // 代理模式下不需要前端密钥
-      chatModel: global.defaultModel || (window.CHAT_LOCAL_MODEL || '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05'),
+      chatModel: global.defaultModel || '[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05',
       avatarEnabled: false,
       avatarImage: '', // 可选自定义头像URL，留空则使用emoji
       avatarSize: 72,
@@ -123,15 +119,8 @@
     }
   }
   function saveCfg(cfg){ 
-    // 如果是共享模式，不保存API Key到本地存储
-    const global = STATE.globalConfig;
-    if (global?.sharedMode && global?.apiKey) {
-      const toSave = Object.assign({}, cfg);
-      delete toSave.chatKey; // 不保存共享的API Key
-      localStorage.setItem(CFG_KEY, JSON.stringify(toSave));
-    } else {
-      localStorage.setItem(CFG_KEY, JSON.stringify(cfg));
-    }
+    // 直接保存配置（已不再使用前端API密钥/共享模式）
+    localStorage.setItem(CFG_KEY, JSON.stringify(cfg));
   }
 
   function getUIRoot(){
@@ -322,85 +311,16 @@
       <div class="chat-config hidden">
         <div class="config-section">
           <h4>🌾 高粱米AI设置</h4>
-          <label>API Base <input type="text" name="chatBase" list="chatBaseList" placeholder="https://openai-compatible-api-proxy-for-z-myg0.onrender.com"></label>
-          <label>API Key <input type="password" name="chatKey" placeholder="API密钥（仅本机存储）" autocomplete="new-password"></label>
           <label>AI模型
             <input type="text" name="chatModel" list="chatModelList" placeholder="如 gpt-4o-mini 或 自定义模型标识">
             <datalist id="chatModelList">
+              <option value="[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05"></option>
+              <option value="[CLI反代]gemini-2.5-pro-preview-06-05"></option>
               <option value="GLM-4.5"></option>
               <option value="gpt-4o-mini"></option>
-              <option value="gpt-3.5-turbo"></option>
-              <option value="qwen2.5-7b-instruct"></option>
             </datalist>
           </label>
-          <label>流式输出
-            <select name="streamingEnabled">
-              <option value="true">是</option>
-              <option value="false">否</option>
-            </select>
-          </label>
-          <label>显示头像
-            <select name="avatarEnabled">
-              <option value="true">是</option>
-              <option value="false">否</option>
-            </select>
-          </label>
-          <label>头像URL <input type="text" name="avatarImage" placeholder="可选：二次元形象图片URL"></label>
-          <label>头像尺寸 <input type="number" name="avatarSize" placeholder="72" min="48" max="160"></label>
-          <hr/>
-          <h4>🎀 Live2D 看板娘</h4>
-          <label>启用Live2D
-            <select name="live2dEnabled">
-              <option value="true">是</option>
-              <option value="false">否</option>
-            </select>
-          </label>
-          <label>Live2D模型
-            <select name="live2dModel">
-              <option value="shizuku">Shizuku（清新）</option>
-              <option value="koharu">Koharu（甜美）</option>
-              <option value="izumi">Izumi（成熟）</option>
-              <option value="hiyori">Hiyori（示例）</option>
-              <option value="haru">Haru（示例）</option>
-            </select>
-          </label>
-          <label>Live2D宽度 <input type="number" name="live2dWidth" placeholder="180" min="100" max="400"></label>
-          <label>Live2D高度 <input type="number" name="live2dHeight" placeholder="320" min="160" max="600"></label>
-          <label>移动端显示
-            <select name="live2dMobile">
-              <option value="false">否</option>
-              <option value="true">是</option>
-            </select>
-          </label>
-          <hr/>
-          <h4>🗨️ 聊天气泡位置</h4>
-          <label>聊天气泡偏移X <input type="number" name="bubbleOffsetX" placeholder="0" min="-300" max="300"></label>
-          <label>聊天气泡偏移Y <input type="number" name="bubbleOffsetY" placeholder="36" min="-300" max="300"></label>
-          <hr/>
-          <h4>💡 入口小气泡</h4>
-          <label>启用入口气泡
-            <select name="entryBubbleEnabled">
-              <option value="true">是</option>
-              <option value="false">否</option>
-            </select>
-          </label>
-          <label>位置
-            <select name="entryBubblePos">
-              <option value="top-right">top-right（默认）</option>
-              <option value="top-left">top-left</option>
-              <option value="right-top">right-top</option>
-              <option value="left-top">left-top</option>
-              <option value="custom">custom（拖拽自定义）</option>
-            </select>
-          </label>
-          <label>偏移X <input type="number" name="entryBubbleOffsetX" placeholder="0" min="-200" max="200"></label>
-          <label>偏移Y <input type="number" name="entryBubbleOffsetY" placeholder="-8" min="-200" max="200"></label>
         </div>
-        <datalist id="chatBaseList">
-          <option value="https://openai-compatible-api-proxy-for-z-myg0.onrender.com"></option>
-          <option value="https://api.openai.com"></option>
-          <option value="https://api.siliconflow.cn/v1"></option>
-        </datalist>
         <button class="save">保存配置</button>
       </div>`;
     document.body.appendChild(bubble);
@@ -416,52 +336,32 @@
       if(e.key==='Enter') onSend();
     });
 
-    // init config form
+    // init config form（精简为仅选择模型）
     const cfg2 = loadCfg();
     const form = bubble.querySelector('.chat-config');
-    form.querySelector('[name=chatBase]').value = cfg2.chatBase || 'https://huggingface.qzz.io';
-    form.querySelector('[name=chatKey]').value = cfg2.chatKey || '';
-    form.querySelector('[name=chatModel]').value = cfg2.chatModel || 'GLM-4.5';
-    form.querySelector('[name=avatarEnabled]').value = String(cfg2.avatarEnabled !== false);
-    form.querySelector('[name=avatarImage]').value = cfg2.avatarImage || '';
-    form.querySelector('[name=avatarSize]').value = (cfg2.avatarSize || 72);
-    form.querySelector('[name=live2dEnabled]').value = String(cfg2.live2dEnabled !== false);
-    form.querySelector('[name=live2dModel]').value = (cfg2.live2dModel || 'shizuku');
-    form.querySelector('[name=live2dWidth]').value = (cfg2.live2dWidth || 180);
-    form.querySelector('[name=live2dHeight]').value = (cfg2.live2dHeight || 320);
-    form.querySelector('[name=live2dMobile]').value = String(!!cfg2.live2dMobile);
-    form.querySelector('[name=streamingEnabled]').value = String(cfg2.streamingEnabled !== false);
-    form.querySelector('[name=bubbleOffsetX]').value = Number(cfg2.bubbleOffsetX || 0);
-    form.querySelector('[name=bubbleOffsetY]').value = Number(cfg2.bubbleOffsetY ?? 24);
-    form.querySelector('[name=entryBubbleEnabled]').value = String(cfg2.entryBubbleEnabled !== false);
-    form.querySelector('[name=entryBubblePos]').value = String(cfg2.entryBubblePos || 'top-right');
-    form.querySelector('[name=entryBubbleOffsetX]').value = Number(cfg2.entryBubbleOffsetX || 0);
-    form.querySelector('[name=entryBubbleOffsetY]').value = Number(cfg2.entryBubbleOffsetY ?? -8);
+    form.innerHTML = `
+      <div class="config-section">
+        <h4>🌾 高粱米AI设置</h4>
+        <label>AI模型
+          <input type="text" name="chatModel" list="chatModelList" placeholder="如 gpt-4o-mini 或 自定义模型标识">
+          <datalist id="chatModelList">
+            <option value="[CLI反代]流式抗截断/gemini-2.5-pro-preview-06-05"></option>
+            <option value="[CLI反代]gemini-2.5-pro-preview-06-05"></option>
+            <option value="GLM-4.5"></option>
+            <option value="gpt-4o-mini"></option>
+          </datalist>
+        </label>
+      </div>
+      <button class="save">保存配置</button>
+    `;
+    form.querySelector('[name=chatModel]').value = cfg2.chatModel || (STATE.globalConfig && STATE.globalConfig.defaultModel) || 'GLM-4.5';
     form.querySelector('.save').addEventListener('click', ()=>{
-      const next = {
-        chatBase: form.querySelector('[name=chatBase]').value.trim() || 'https://huggingface.qzz.io',
-        chatKey: form.querySelector('[name=chatKey]').value.trim(),
-        chatModel: form.querySelector('[name=chatModel]').value.trim() || 'GLM-4.5',
-        streamingEnabled: form.querySelector('[name=streamingEnabled]').value === 'true',
-        avatarEnabled: form.querySelector('[name=avatarEnabled]').value === 'true',
-        avatarImage: form.querySelector('[name=avatarImage]').value.trim(),
-        avatarSize: Math.max(48, Math.min(160, parseInt(form.querySelector('[name=avatarSize]').value, 10) || 72)),
-        live2dEnabled: form.querySelector('[name=live2dEnabled]').value === 'true',
-        live2dModel: form.querySelector('[name=live2dModel]').value || 'shizuku',
-        live2dWidth: Math.max(100, Math.min(400, parseInt(form.querySelector('[name=live2dWidth]').value, 10) || 180)),
-        live2dHeight: Math.max(160, Math.min(600, parseInt(form.querySelector('[name=live2dHeight]').value, 10) || 320)),
-        live2dMobile: form.querySelector('[name=live2dMobile]').value === 'true',
-        bubbleOffsetX: parseInt(form.querySelector('[name=bubbleOffsetX]').value, 10) || 0,
-        bubbleOffsetY: (function(){ const v = parseInt(form.querySelector('[name=bubbleOffsetY]').value, 10); return Number.isFinite(v)? v : 24; })(),
-        entryBubbleEnabled: form.querySelector('[name=entryBubbleEnabled]').value === 'true',
-        entryBubblePos: form.querySelector('[name=entryBubblePos]').value || 'top-right',
-        entryBubbleOffsetX: parseInt(form.querySelector('[name=entryBubbleOffsetX]').value, 10) || 0,
-        entryBubbleOffsetY: (function(){ const v = parseInt(form.querySelector('[name=entryBubbleOffsetY]').value, 10); return Number.isFinite(v)? v : -8; })()
-      };
+      const curr = loadCfg();
+      const next = Object.assign({}, curr, {
+        chatModel: form.querySelector('[name=chatModel]').value.trim() || (STATE.globalConfig && STATE.globalConfig.defaultModel) || curr.chatModel
+      });
       saveCfg(next);
-      ensureEntryBubble(next);
-      positionEntryBubble();
-      alert('配置已保存（仅存于本机）。如修改了头像/Live2D/入口气泡相关设置，建议刷新页面以应用。');
+      alert('模型已保存（仅存于本机）。');
     });
   }
 
@@ -587,7 +487,7 @@
 
     try{
       setBusy(true);
-      checkAdminPermission();
+      // 管理面板已移除：不再进行管理员权限检查
       const sys = getSystemPrompt();
       const cfg = loadCfg();
       const modelParams = getModelParams();
@@ -615,35 +515,23 @@
     
     const messages = [{ role: 'system', content: system }, ...STATE.messages, { role:'user', content: userText }];
     
+    // 统一使用 Cloudflare Workers 代理
     let resp;
-    if (global?.mode === 'direct' && global?.apiKey) {
-      // 本地开发模式：直接调用API
-      const url = new URL('/v1/chat/completions', cfg.chatBase).toString();
-      resp = await fetch(url, {
-        method:'POST',
-        headers:{ 'Content-Type':'application/json', 'Authorization':`Bearer ${global.apiKey}` },
-        body: JSON.stringify({ model: cfg.chatModel, messages, temperature: modelParams.temperature, max_tokens: modelParams.max_tokens, stream: false, stop: ["让我们一步一步思考","思考过程","用户询问"] })
-      });
-    } else {
-      // 生产模式：调用Cloudflare Workers代理
-      // 优先使用代码内置的全局代理地址，避免被本地存储的旧 chatProxy 覆盖
-      const proxyUrl = (global?.proxyUrl) || cfg.chatProxy;
-      if (!proxyUrl) {
-        throw new Error('代理服务未配置，请联系博主');
-      }
-      
-      resp = await fetch(proxyUrl, {
-        method:'POST',
-        headers:{ 'Content-Type':'application/json' },
-        body: JSON.stringify({ 
-          model: cfg.chatModel, 
-          messages, 
-          temperature: modelParams.temperature, 
-          max_tokens: modelParams.max_tokens, 
-          stream: false 
-        })
-      });
+    const proxyUrl = (global?.proxyUrl) || cfg.chatProxy;
+    if (!proxyUrl) {
+      throw new Error('代理服务未配置，请联系博主');
     }
+    resp = await fetch(proxyUrl, {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify({ 
+        model: cfg.chatModel, 
+        messages, 
+        temperature: modelParams.temperature, 
+        max_tokens: modelParams.max_tokens, 
+        stream: false 
+      })
+    });
     
     if (!resp.ok) {
       const errorText = await resp.text();
@@ -672,35 +560,23 @@
     body.appendChild(node);
     body.scrollTop = body.scrollHeight;
 
+    // 统一使用 Cloudflare Workers 代理
     let resp;
-    if (global?.mode === 'direct' && global?.apiKey) {
-      // 本地开发模式：直接调用API
-      const url = new URL('/v1/chat/completions', cfg.chatBase).toString();
-      resp = await fetch(url, {
-        method:'POST',
-        headers:{ 'Content-Type':'application/json', 'Authorization':`Bearer ${global.apiKey}` },
-        body: JSON.stringify({ model: cfg.chatModel, messages, temperature: modelParams.temperature, max_tokens: modelParams.max_tokens, stream: true, stop: ["让我们一步一步思考","思考过程","用户询问"] })
-      });
-    } else {
-      // 生产模式：调用Cloudflare Workers代理
-      // 优先使用代码内置的全局代理地址，避免被本地存储的旧 chatProxy 覆盖
-      const proxyUrl = (global?.proxyUrl) || cfg.chatProxy;
-      if (!proxyUrl) {
-        throw new Error('代理服务未配置，请联系博主');
-      }
-      
-      resp = await fetch(proxyUrl, {
-        method:'POST',
-        headers:{ 'Content-Type':'application/json' },
-        body: JSON.stringify({ 
-          model: cfg.chatModel, 
-          messages, 
-          temperature: modelParams.temperature, 
-          max_tokens: modelParams.max_tokens, 
-          stream: true 
-        })
-      });
+    const proxyUrl = (global?.proxyUrl) || cfg.chatProxy;
+    if (!proxyUrl) {
+      throw new Error('代理服务未配置，请联系博主');
     }
+    resp = await fetch(proxyUrl, {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify({ 
+        model: cfg.chatModel, 
+        messages, 
+        temperature: modelParams.temperature, 
+        max_tokens: modelParams.max_tokens, 
+        stream: true 
+      })
+    });
     if (!resp.ok || !resp.body) {
       const txt = await resp.text().catch(()=> '');
       throw new Error('对话失败：' + (txt||resp.status));
@@ -817,31 +693,13 @@
 
   // Initialize after DOM ready
   function ensureLocalInject(){
-    if (!isLocalHost()) return;
-    loadScript('/js/chat-local.js', ()=>{
-      try{
-        const curr = loadCfg();
-        const next = Object.assign({}, curr);
-        if (window.CHAT_LOCAL_BASE) next.chatBase = window.CHAT_LOCAL_BASE;
-        if (window.CHAT_LOCAL_MODEL) next.chatModel = window.CHAT_LOCAL_MODEL;
-        if (window.CHAT_LOCAL_KEY) next.chatKey = window.CHAT_LOCAL_KEY;
-        if (typeof window.CHAT_LOCAL_STREAMING !== 'undefined') next.streamingEnabled = !!window.CHAT_LOCAL_STREAMING;
-        saveCfg(next);
-        // 若表单已存在则更新显示
-        const form = document.querySelector('#chat-bubble .chat-config');
-        if (form){
-          form.querySelector('[name=chatBase]').value = next.chatBase;
-          form.querySelector('[name=chatModel]').value = next.chatModel;
-          form.querySelector('[name=chatKey]').value = next.chatKey || '';
-          form.querySelector('[name=streamingEnabled]').value = String(next.streamingEnabled);
-        }
-      }catch(e){ console.warn('local overrides failed', e); }
-    });
+    // no-op: 已移除本地直连与前端密钥注入
+    return;
   }
 
   if (document.readyState==='loading') document.addEventListener('DOMContentLoaded', ()=>{ 
     loadGlobalConfig(); // 首先加载全局配置
-    loadScript('/js/chat-admin.js', ()=>{}); 
+    // 管理面板已移除：不再加载 /js/chat-admin.js
     ensureLocalInject(); 
     ensureUI(); 
     ensureEntryBubble(loadCfg()); 
@@ -850,7 +708,7 @@
   });
   else { 
     loadGlobalConfig(); // 首先加载全局配置
-    loadScript('/js/chat-admin.js', ()=>{}); 
+    // 管理面板已移除：不再加载 /js/chat-admin.js
     ensureLocalInject(); 
     ensureUI(); 
     ensureEntryBubble(loadCfg()); 


### PR DESCRIPTION
- unify frontend to always use Cloudflare Worker proxy; remove direct mode path
- simplify settings UI (remove API Base/Key fields)
- add safe local proxy override for dev (localStorage 'chat-proxy-override' or window.CHAT_PROXY_DEV)
- bump chat.js cache-busting version in body-end.njk
- deprecate chat-local.template.js with docs to use wrangler dev
- update blog post: add local dev & testing steps for unified proxy mode